### PR TITLE
Apples give 2 HP instead of 1 HP, bread gives 5 HP instead of 4 HP

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1349,7 +1349,7 @@ minetest.register_node("default:apple", {
 		fixed = {-0.2, -0.5, -0.2, 0.2, 0, 0.2}
 	},
 	groups = {fleshy=3,dig_immediate=3,flammable=2,leafdecay=3,leafdecay_drop=1},
-	on_use = minetest.item_eat(1),
+	on_use = minetest.item_eat(2),
 	sounds = default.node_sound_leaves_defaults(),
 	after_place_node = function(pos, placer, itemstack)
 		if placer:is_player() then

--- a/mods/farming/init.lua
+++ b/mods/farming/init.lua
@@ -24,7 +24,7 @@ minetest.register_craftitem("farming:flour", {
 minetest.register_craftitem("farming:bread", {
 	description = "Bread",
 	inventory_image = "farming_bread.png",
-	on_use = minetest.item_eat(4),
+	on_use = minetest.item_eat(5),
 })
 
 minetest.register_craft({


### PR DESCRIPTION
Apples used to give 4 HP, currently they give 1 HP. This feels quite low, so I have increased it to 2.

Bread always gave 4 HP, but it is complicated to make, so it deserves giving 5 HP.
