### PR TITLE
Flowers: Add mushrooms to mgv6

### DIFF
--- a/mods/flowers/mapgen.lua
+++ b/mods/flowers/mapgen.lua
@@ -17,6 +17,25 @@ local function register_flower(name)
 	})
 end
 
+local function register_mushroom(name)
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = {"default:dirt_with_grass", "default:dirt"},
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.006,
+			spread = {x=100, y=100, z=100},
+			seed = 7133,
+			octaves = 3,
+			persist = 0.6
+		},
+		y_min = -31000,
+		y_max = 30,
+		decoration = "flowers:"..name,
+	})
+end
+
 function flowers.register_mgv6_decorations()
 	register_flower("rose")
 	register_flower("tulip")
@@ -24,12 +43,14 @@ function flowers.register_mgv6_decorations()
 	register_flower("geranium")
 	register_flower("viola")
 	register_flower("dandelion_white")
+
+	register_mushroom("mushroom_brown")
+	register_mushroom("mushroom_red")
 end
 
 -- Enable in mapgen v6 only
 
-local mg_params = minetest.get_mapgen_params()
-if mg_params.mgname == "v6" then
+if minetest.get_mapgen_params().mgname == "v6" then
 	flowers.register_mgv6_decorations()
 end
 


### PR DESCRIPTION
![screenshot_20150722_002809](https://cloud.githubusercontent.com/assets/3686677/8814818/ca3bdf5a-3008-11e5-8b89-25b642c3a6ac.png)

^ Example of a fairly high density area.

Requested by Novatux https://github.com/minetest/minetest_game/pull/565
Each mushroom type has a rarity equal to any one of the flower types. Density variation by noise.
