### PR TITLE
Add access privilege that allows players to bypass protection.

### DIFF
--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -5,7 +5,8 @@ bones = {}
 
 local function is_owner(pos, name)
 	local owner = minetest.get_meta(pos):get_string("owner")
-	if owner == "" or owner == name then
+	local privs = minetest.get_player_privs(name)
+	if owner == "" or owner == name or privs.access then
 		return true
 	end
 	return false

--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -8,6 +8,7 @@ default = {}
 
 default.LIGHT_MAX = 14
 
+minetest.register_privilege("access", "Can open any locked door or chest")
 -- GUI related stuff
 default.gui_bg = "bgcolor[#080808BB;true]"
 default.gui_bg_img = "background[5,5;1,1;gui_formbg.png;true]"

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1353,10 +1353,9 @@ local function get_locked_chest_formspec(pos)
 end
 
 local function has_locked_chest_privilege(meta, player)
-	if player:get_player_name() ~= meta:get_string("owner") then
-		return false
-	end
-	return true
+	local name = player:get_player_name()
+	local owner = meta:get_string("owner")
+	return name == owner or minetest.get_player_privs(name).access
 end
 
 minetest.register_node("default:chest", {

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -158,9 +158,10 @@ function doors.register_door(name, def)
 		if not def.only_placer_can_open then
 			return true
 		end
-		local meta = minetest.get_meta(pos)
+		local owner = minetest.get_meta(pos):get_string("doors_owner")
 		local pn = player:get_player_name()
-		return meta:get_string("doors_owner") == pn
+		return owner == pn or minetest.get_player_privs(pn).access
+
 	end
 
 	local function on_rotate(pos, node, dir, user, check_name, mode, new_param2)
@@ -432,9 +433,9 @@ function doors.register_trapdoor(name, def)
 		if not def.only_placer_can_open then
 			return true
 		end
-		local meta = minetest.get_meta(pos)
+		local owner = minetest.get_meta(pos):get_string("doors_owner")
 		local pn = player:get_player_name()
-		return meta:get_string("doors_owner") == pn
+		return owner == pn or minetest.get_player_privs(pn).access
 	end
 
 	def.on_rightclick = function (pos, node, clicker, itemstack, pointed_thing)


### PR DESCRIPTION
The access privilege allows players that have it to bypass protection on locked doors/trapdoors, chests and bones. Currently there is no way to do this without mods.
