### PR TITLE
Fire: Add 'permanent flame' node

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -9,7 +9,8 @@
 # 0 to disable
 #share_bones_time = 1200
 
-# Whether fire should be disabled (all fire nodes will instantly disappear)
+# Whether standard fire should be disabled ('basic flame' nodes will disappear)
+# 'permanent flame' nodes will remain with either setting
 #disable_fire = false
 
 # Whether steel tools, torches and cobblestone should be given to new players


### PR DESCRIPTION
Update 'disable fire' documentation in conf.example

See #191 and #676 
The new node still ignites neighbouring flammable nodes, still causes player damage and is still extinguished by neighbouring water / ice / snow.
It does not burn out with time or remove neighbouring flammable nodes.
It is silent due to current problems with sounds.
It is still usable when fire is disabled.
