### PR TITLE
configurable tree growth light level

### DIFF
--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -17,7 +17,8 @@ local function can_grow(pos)
 		return false
 	end
 	local light_level = minetest.get_node_light(pos)
-	if not light_level or light_level < 13 then
+	local min_light_level = tonumber(minetest.setting_get("trees_min_light_level")) or 13
+	if not light_level or light_level < min_light_level then
 		return false
 	end
 	return true

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -5,7 +5,8 @@
 -- 'Can grow' function
 
 local random = math.random
-
+local min_light_level = tonumber(minetest.setting_get("trees_min_light_level")) or 13
+	
 local function can_grow(pos)
 	local node_under = minetest.get_node_or_nil({x = pos.x, y = pos.y - 1, z = pos.z})
 	if not node_under then
@@ -17,7 +18,6 @@ local function can_grow(pos)
 		return false
 	end
 	local light_level = minetest.get_node_light(pos)
-	local min_light_level = tonumber(minetest.setting_get("trees_min_light_level")) or 13
 	if not light_level or light_level < min_light_level then
 		return false
 	end


### PR DESCRIPTION
Allow the tree's min light level for growth to be configurable in the config, but default to 13 if not defined.
Users/server owners can just add trees_min_light_level=3 etc to there config for it to take effect.

This should make everyone happy. those who like the current system and those who want the old light levels back like @Megaf
#724
