### PR TITLE
Default: Slightly reduce alpha of water post effect colour

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -1027,7 +1027,7 @@ minetest.register_node("default:water_source", {
 	liquid_alternative_flowing = "default:water_flowing",
 	liquid_alternative_source = "default:water_source",
 	liquid_viscosity = 1,
-	post_effect_color = {a = 120, r = 30, g = 60, b = 90},
+	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1},
 })
 
@@ -1072,7 +1072,7 @@ minetest.register_node("default:water_flowing", {
 	liquid_alternative_flowing = "default:water_flowing",
 	liquid_alternative_source = "default:water_source",
 	liquid_viscosity = 1,
-	post_effect_color = {a = 120, r = 30, g = 60, b = 90},
+	post_effect_color = {a = 103, r = 30, g = 60, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1,
 		not_in_creative_inventory = 1},
 })
@@ -1120,7 +1120,7 @@ minetest.register_node("default:river_water_source", {
 	liquid_viscosity = 1,
 	liquid_renewable = false,
 	liquid_range = 2,
-	post_effect_color = {a = 120, r = 30, g = 76, b = 90},
+	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1},
 })
 
@@ -1167,7 +1167,7 @@ minetest.register_node("default:river_water_flowing", {
 	liquid_viscosity = 1,
 	liquid_renewable = false,
 	liquid_range = 2,
-	post_effect_color = {a = 120, r = 30, g = 76, b = 90},
+	post_effect_color = {a = 103, r = 30, g = 76, b = 90},
 	groups = {water = 3, liquid = 3, puts_out_fire = 1,
 		not_in_creative_inventory = 1},
 })
@@ -1216,7 +1216,7 @@ minetest.register_node("default:lava_source", {
 	liquid_viscosity = 7,
 	liquid_renewable = false,
 	damage_per_second = 4 * 2,
-	post_effect_color = {a = 192, r = 255, g = 64, b = 0},
+	post_effect_color = {a = 191, r = 255, g = 64, b = 0},
 	groups = {lava = 3, liquid = 2, hot = 3, igniter = 1},
 })
 
@@ -1263,7 +1263,7 @@ minetest.register_node("default:lava_flowing", {
 	liquid_viscosity = 7,
 	liquid_renewable = false,
 	damage_per_second = 4 * 2,
-	post_effect_color = {a = 192, r = 255, g = 64, b = 0},
+	post_effect_color = {a = 191, r = 255, g = 64, b = 0},
 	groups = {lava = 3, liquid = 2, hot = 3, igniter = 1,
 		not_in_creative_inventory = 1},
 })


### PR DESCRIPTION
"To make water a little clearer and feel purer
Also correct lava alpha values from 192 to 191"

Classic value 64.
Recent value 120 commited by Calinou 6 June 750f9575af15d92abc397d99aba90005fd3cade8
This commit 103.

I like the recent increase in water alpha and the correction of the colour, but find the post effect colour just a little too dark, murky and hard on the eyes, not quite balanced with how clear and pure the water looks from above.

![screenshot_20151207_010305](https://cloud.githubusercontent.com/assets/3686677/11616983/691d3310-9c80-11e5-89c0-356f90d00b5a.png)

![screenshot_20151207_010255](https://cloud.githubusercontent.com/assets/3686677/11616986/6e126b06-9c80-11e5-8335-ec8cee1c3446.png)

^ With this commit.

![screenshot_20151209_142056](https://cloud.githubusercontent.com/assets/3686677/11687755/6c2f35f6-9e80-11e5-9146-1cf23826dd23.png)

^ Current value.
