### PR TITLE
Create API for fence.register, and use it.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -110,6 +110,24 @@ doors.register_trapdoor(name, def)
 		will be overwritten by the trapdoor registration function
 }
 
+Fence API
+---------
+Allows creation of new fences with "fencelike" drawtype.
+
+default.register_fence(name, item definition)
+ ^ Registers a new fence. Custom fields texture and material are required, as
+ ^ are name and description. The rest is optional. You can pass most normal
+ ^ nodedef fields here except drawtype. The fence group will always be added
+ ^ for this node.
+
+#fence definition
+	name = "default:fence_wood",
+	description = "Wooden Fence",
+	texture = "default_wood.png",
+	material = "default:wood",
+	groups = {choppy=2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults(),
+
 Farming API
 -----------
 The farming API allows you to easily register plants and hoes.

--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -43,14 +43,6 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:fence_wood 2',
-	recipe = {
-		{'group:stick', 'group:stick', 'group:stick'},
-		{'group:stick', 'group:stick', 'group:stick'},
-	}
-})
-
-minetest.register_craft({
 	output = 'default:sign_wall',
 	recipe = {
 		{'group:wood', 'group:wood', 'group:wood'},

--- a/mods/default/functions.lua
+++ b/mods/default/functions.lua
@@ -210,6 +210,51 @@ end
 
 
 --
+-- Fence registration helper
+--
+function default.register_fence(name, def)
+	minetest.register_craft({
+		output = name .. " 4",
+		recipe = {
+			{ def.material, 'group:stick', def.material },
+			{ def.material, 'group:stick', def.material },
+		}
+	})
+
+	local fence_texture = "default_fence_overlay.png^" .. def.texture ..
+			"^default_fence_overlay.png^[makealpha:255,126,126"
+	-- Allow almost everything to be overridden
+	local default_fields = {
+		paramtype = "light",
+		drawtype = "fencelike",
+		inventory_image = fence_texture,
+		wield_image = fence_texture,
+		tiles = { def.texture },
+		sunlight_propagates = true,
+		is_ground_content = false,
+		selection_box = {
+			type = "fixed",
+			fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
+		},
+		groups = {},
+	}
+	for k, v in pairs(default_fields) do
+		if not def[k] then
+			def[k] = v
+		end
+	end
+
+	-- Always add to the fence group, even if no group provided
+	def.groups.fence = 1
+
+	def.texture = nil
+	def.material = nil
+
+	minetest.register_node(name, def)
+end
+
+
+--
 -- Leafdecay
 --
 

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -151,6 +151,10 @@ default:sign_wall
 default:ladder
 
 default:fence_wood
+default:fence_acacia_wood
+default:fence_junglewood
+default:fence_pine_wood
+default:fence_aspen_wood
 
 default:glass
 default:obsidian_glass
@@ -1674,26 +1678,45 @@ minetest.register_node("default:ladder", {
 	sounds = default.node_sound_wood_defaults(),
 })
 
-
-local fence_texture =
-	"default_fence_overlay.png^default_wood.png^default_fence_overlay.png^[makealpha:255,126,126"
-minetest.register_node("default:fence_wood", {
+default.register_fence("default:fence_wood", {
 	description = "Wooden Fence",
-	drawtype = "fencelike",
-	tiles = {"default_wood.png"},
-	inventory_image = fence_texture,
-	wield_image = fence_texture,
-	paramtype = "light",
-	sunlight_propagates = true,
-	is_ground_content = false,
-	selection_box = {
-		type = "fixed",
-		fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
-	},
+	texture = "default_wood.png",
+	material = "default:wood",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
-	sounds = default.node_sound_wood_defaults(),
+	sounds = default.node_sound_wood_defaults()
 })
 
+default.register_fence("default:fence_acacia_wood", {
+	description = "Acacia Fence",
+	texture = "default_acacia_wood.png",
+	material = "default:acacia_wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_junglewood", {
+	description = "Junglewood Fence",
+	texture = "default_junglewood.png",
+	material = "default:junglewood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_pine_wood", {
+	description = "Pine Fence",
+	texture = "default_pine_wood.png",
+	material = "default:pine_wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
+
+default.register_fence("default:fence_aspen_wood", {
+	description = "Aspen Fence",
+	texture = "default_aspen_wood.png",
+	material = "default:aspen_wood",
+	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
+	sounds = default.node_sound_wood_defaults()
+})
 
 minetest.register_node("default:glass", {
 	description = "Glass",


### PR DESCRIPTION
This converts the call to minetest.register() for the default
fence node, so it can be called by other mods to quickly
setup other fences.

Since this creates an API, insert it into the game_api.txt.

The api looks like minetest.register(name, {def}), and has two
uncommon fields: "texture" and "material".

I'm not modifying the default fence recipe. Instead, this version
adds acacia sticks, pine sticks, junglewood sticks. This simplifies
the API and simplifies crafting, and is easier to remember, and
doesn't invent a new craft recipe that is hard to guess.

Lastly, adds pine, junglewood and acacia fences.

Textures for the new sticks. I verified all of minetest_game only
ever looks at group:stick for other material, so this prevents no
surprise to any player.

This is a from-scratch implementation, written by heart but inspired
by (#665 - Add many wooden fences).

The visual that fences connect strangely needs to be fixed in
content_mapblock.cpp, something that can easily be done.
