### PR TITLE
New trapdoor recipe.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -530,11 +530,10 @@ doors.register_trapdoor("doors:trapdoor_steel", {
 })
 
 minetest.register_craft({
-	output = 'doors:trapdoor 2',
+	output = 'doors:trapdoor',
 	recipe = {
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'group:wood', 'group:wood'},
-		{'', '', ''},
+		{'group:wood', 'group:wood'},
+		{'group:wood', 'group:wood'},
 	}
 })
 


### PR DESCRIPTION
Related: #779, @535e611e

Trapdoors are square, not rectangular. The rectangular recipes are
already used for glass panes, walls, doors, but no square recipes
existed until #779 got fixed.

This course of events suggests that it was a mistake to pick the
original trapdoor recipe. Instead, we propose to use a similar
2x2 recipe for the trapdoor, which is square. The recipe can be
made in any of the 4 corners of the crafting grid.
