### PR TITLE
Fix blank page in creative on some rare case

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -42,7 +42,7 @@ creative_inventory.init_creative_inventory = function(player)
 	})
 
 	creative_inventory.update(player_name, nil, 2)
-	--print("creative inventory size: "..dump(creative_inventory.creative_inventory_size))
+	--print("creative inventory size: "..dump(creative_inventory[player_name].size))
 end
 
 local function tab_category(tab_id)
@@ -128,19 +128,19 @@ end
 
 creative_inventory.set_crafting_formspec = function(player)
 	player:set_inventory_formspec([[
-		size[8,7.5]
-		list[current_player;craft;2,0.25;3,3;]
- 		list[current_player;craftpreview;6,1.25;1,1;]
-		list[current_player;main;0,3.6;8,1;]
-		list[current_player;main;0,4.75;8,3;8]
-		list[detached:creative_trash;main;0,2.25;1,1;]
-		image[0.06,2.35;0.8,0.8;trash_icon.png]
-		image[5,1.25;1,1;gui_furnace_arrow_bg.png^[transformR270]
+		size[8,8.6]
+		list[current_player;craft;2,0.75;3,3;]
+		list[current_player;craftpreview;6,1.75;1,1;]
+		list[current_player;main;0,4.7;8,1;]
+		list[current_player;main;0,5.85;8,3;8]
+		list[detached:creative_trash;main;0,2.75;1,1;]
+		image[0.06,2.85;0.8,0.8;trash_icon.png]
+		image[5,1.75;1,1;gui_furnace_arrow_bg.png^[transformR270]
 		tabheader[0,0;tabs;Crafting,All,Nodes,Tools,Items;1;true;false]
 		listring[current_player;main]
 		listring[current_player;craft]
 		]] ..
-		default.get_hotbar_bg(0,3.6)..
+		default.get_hotbar_bg(0,4.7)..
 		default.gui_bg .. default.gui_bg_img .. default.gui_slots
 	)
 end
@@ -191,6 +191,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			start_i = start_i - 3*8
 			if start_i < 0 then
 				start_i = inv_size - (inv_size % (3*8))
+				if inv_size == start_i then
+					start_i = math.max(0, inv_size - (3*8))
+				end
 			end
 		elseif fields.creative_next then
 			start_i = start_i + 3*8


### PR DESCRIPTION
When you click on previous from page 1 and if the number of items is a multiple of 24 (= inventory size), then `start_i` is equal to `inv_size` (thus with no rest), resulting in a blank page.
