### PR TITLE
Basic stone walls, using NDT_CONNECTED.

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -139,6 +139,17 @@ Allows creation of new fences with "fencelike" drawtype.
 	groups = {choppy = 2, oddly_breakable_by_hand = 2, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 
+#Walls API
+---------
+The walls API allows easy addition of stone auto-connecting wall nodes.
+
+walls.register(name, desc, texture, mat, sounds)
+^ name = "walls:stone_wall". Node name.
+^ desc = "A Stone wall"
+^ texture = "default_stone.png"
+^ mat = "default:stone". Used to auto-generate crafting recipe.
+^ sounds = sounds: see [#Default sounds]
+
 Farming API
 -----------
 

--- a/mods/walls/depends.txt
+++ b/mods/walls/depends.txt
@@ -1,0 +1,1 @@
+default

--- a/mods/walls/init.lua
+++ b/mods/walls/init.lua
@@ -1,0 +1,61 @@
+
+--[[
+
+Walls mod for Minetest
+
+Copyright (C) 2015 Auke Kok <sofar@foo-projects.org>
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+--]]
+
+walls = {}
+
+walls.register = function(wall_name, wall_desc, wall_texture, wall_mat, wall_sounds)
+	-- inventory node, and pole-type wall start item
+	minetest.register_node(wall_name, {
+		description = wall_desc,
+		drawtype = "nodebox",
+		node_box = {
+			type = "connected",
+			fixed = {{-1/4, -1/2, -1/4, 1/4, 1/2, 1/4}},
+			-- connect_bottom =
+			connect_front = {{-3/16, -1/2, -1/2,  3/16, 3/8, -1/4}},
+			connect_left = {{-1/2, -1/2, -3/16, -1/4, 3/8,  3/16}},
+			connect_back = {{-3/16, -1/2,  1/4,  3/16, 3/8,  1/2}},
+			connect_right = {{ 1/4, -1/2, -3/16,  1/2, 3/8,  3/16}},
+		},
+		connects_to = { "group:cracky", "group:wall", "group:stone" },
+		paramtype = "light",
+		is_ground_content = false,
+		tiles = { wall_texture, },
+		walkable = true,
+		groups = { cracky = 3, wall = 1, stone = 2 },
+		sounds = wall_sounds,
+	})
+
+	-- crafting recipe
+	minetest.register_craft({
+		output = wall_name .. " 6",
+		recipe = {
+			{ '', '', '' },
+			{ wall_mat, wall_mat, wall_mat},
+			{ wall_mat, wall_mat, wall_mat},
+		}
+	})
+
+end
+
+walls.register("walls:cobble", "Cobblestone Wall", "default_cobble.png",
+		"default:cobble", default.node_sound_stone_defaults())
+
+walls.register("walls:mossycobble", "Mossy Cobblestone Wall", "default_mossycobble.png",
+		"default:mossycobble", default.node_sound_stone_defaults())
+
+walls.register("walls:desertcobble", "Desert Cobblestone Wall", "default_desert_cobble.png",
+		"default:desert_cobble", default.node_sound_stone_defaults())
+


### PR DESCRIPTION
These basic connected wall nodes automatically connect
to neigboring stone blocks, other wall blocks and anything
that's "cracky". The do not connect to wood (fences will do
that).

The walls are generated using a new walls.register() API.
Documentation on the API is included in game_api.txt.

This change requires minetest/minetest#3503.
