### PR TITLE
Allow building doors on buildable_to nodes.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -183,8 +183,15 @@ function doors.register(name, def)
 		inventory_image = def.inventory_image,
 
 		on_place = function(itemstack, placer, pointed_thing)
-			local pos = pointed_thing.above
-			local node = minetest.get_node(pos)
+			local pos = nil
+
+			local node = minetest.get_node(pointed_thing.under)
+			if minetest.registered_nodes[node.name].buildable_to then
+				pos = pointed_thing.under
+			else
+				pos = pointed_thing.above
+				node = minetest.get_node(pos)
+			end
 
 			if not minetest.registered_nodes[node.name].buildable_to then
 				return itemstack

--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -185,16 +185,26 @@ function doors.register(name, def)
 		on_place = function(itemstack, placer, pointed_thing)
 			local pos = nil
 
+			if not pointed_thing.type == "node" then
+				return itemstack
+			end
+
 			local node = minetest.get_node(pointed_thing.under)
-			if minetest.registered_nodes[node.name].buildable_to then
+			local def = minetest.registered_nodes[node.name]
+			if def and def.on_rightclick then
+				return def.on_rightclick(pointed_thing.under,
+						node, placer, itemstack)
+			end
+
+			if def and def.buildable_to then
 				pos = pointed_thing.under
 			else
 				pos = pointed_thing.above
 				node = minetest.get_node(pos)
-			end
-
-			if not minetest.registered_nodes[node.name].buildable_to then
-				return itemstack
+				def = minetest.registered_nodes[node.name]
+				if not def or not def.buildable_to then
+					return itemstack
+				end
 			end
 
 			local above = { x = pos.x, y = pos.y + 1, z = pos.z }


### PR DESCRIPTION
This code never allowed placing a door on e.g. a grass
plant. The code to handle this isn't that complex. With
this code, doors can be placed on flowers and on normal
node surfaces without issues.

A second patch allows opening and closing doors (etc.)
when wielding a door item.

We also check that we're not right-clicking an entity with
a door in hand, since that would crash the server.
