### PR TITLE
Door protection fix, and fallback compatibility code for mods.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -209,19 +209,19 @@ function doors.register(name, def)
 			end
 
 			local node = minetest.get_node(pointed_thing.under)
-			local def = minetest.registered_nodes[node.name]
-			if def and def.on_rightclick then
-				return def.on_rightclick(pointed_thing.under,
+			local pdef = minetest.registered_nodes[node.name]
+			if pdef and pdef.on_rightclick then
+				return pdef.on_rightclick(pointed_thing.under,
 						node, placer, itemstack)
 			end
 
-			if def and def.buildable_to then
+			if pdef and pdef.buildable_to then
 				pos = pointed_thing.under
 			else
 				pos = pointed_thing.above
 				node = minetest.get_node(pos)
-				def = minetest.registered_nodes[node.name]
-				if not def or not def.buildable_to then
+				pdef = minetest.registered_nodes[node.name]
+				if not pdef or not pdef.buildable_to then
 					return itemstack
 				end
 			end


### PR DESCRIPTION
During a previous fix, I overwrote `def` causing door protection to be broken. This affected newly placed doors only, so it was a bit tricky to spot.

A second patch includes an almost entirely functional replacement for the deprecated door.register_door() API, that will replace old style doors for any mod to new style doors.

The only thing it can't replace is the `tiles` field. It prints out a solid warning about that, and hopefully helps mod developers to convert quickly. If the `tiles` door def is found, no warning is displayed and everything should work well.

I've tested the door API replacement with an old version of "mydoors" (https://github.com/DonBatman/mydoors) which has a ton of doors.
