### PR TITLE
Farming: Trees: Convert saplings and plants to NodeTimerRef.

### DIFF
--- a/mods/default/init.lua
+++ b/mods/default/init.lua
@@ -36,6 +36,7 @@ default.gui_survival_form = "size[8,8.5]"..
 
 -- Load files
 dofile(minetest.get_modpath("default").."/functions.lua")
+dofile(minetest.get_modpath("default").."/trees.lua")
 dofile(minetest.get_modpath("default").."/nodes.lua")
 dofile(minetest.get_modpath("default").."/furnace.lua")
 dofile(minetest.get_modpath("default").."/tools.lua")
@@ -43,6 +44,5 @@ dofile(minetest.get_modpath("default").."/craftitems.lua")
 dofile(minetest.get_modpath("default").."/crafting.lua")
 dofile(minetest.get_modpath("default").."/mapgen.lua")
 dofile(minetest.get_modpath("default").."/player.lua")
-dofile(minetest.get_modpath("default").."/trees.lua")
 dofile(minetest.get_modpath("default").."/aliases.lua")
 dofile(minetest.get_modpath("default").."/legacy.lua")

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -455,6 +455,10 @@ minetest.register_node("default:sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = default.grow_sapling,
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, 0.35, 0.3}
@@ -573,6 +577,10 @@ minetest.register_node("default:junglesapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = default.grow_sapling,
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, 0.35, 0.3}
@@ -634,6 +642,10 @@ minetest.register_node("default:pine_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = default.grow_sapling,
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, 0.35, 0.3}
@@ -695,6 +707,10 @@ minetest.register_node("default:acacia_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = default.grow_sapling,
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, 0.35, 0.3}
@@ -755,6 +771,10 @@ minetest.register_node("default:aspen_sapling", {
 	paramtype = "light",
 	sunlight_propagates = true,
 	walkable = false,
+	on_timer = default.grow_sapling,
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
+	end,
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.3, -0.5, -0.3, 0.3, 0.35, 0.3}

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -59,57 +59,62 @@ end
 
 -- Sapling ABM
 
-minetest.register_abm({
-	nodenames = {"default:sapling", "default:junglesapling",
-		"default:pine_sapling", "default:acacia_sapling",
-		"default:aspen_sapling"},
-	interval = 10,
-	chance = 50,
-	action = function(pos, node)
-		if not default.can_grow(pos) then
-			return
-		end
+function default.grow_sapling(pos)
+	if not default.can_grow(pos) then
+		-- try a bit later again
+		minetest.get_node_timer(pos):start(math.random(240, 600))
+		return
+	end
 
-		local mapgen = minetest.get_mapgen_params().mgname
-		if node.name == "default:sapling" then
-			minetest.log("action", "A sapling grows into a tree at "..
-				minetest.pos_to_string(pos))
-			if mapgen == "v6" then
-				default.grow_tree(pos, random(1, 4) == 1)
-			else
-				default.grow_new_apple_tree(pos)
-			end
-		elseif node.name == "default:junglesapling" then
-			minetest.log("action", "A jungle sapling grows into a tree at "..
-				minetest.pos_to_string(pos))
-			if mapgen == "v6" then
-				default.grow_jungle_tree(pos)
-			else
-				default.grow_new_jungle_tree(pos)
-			end
-		elseif node.name == "default:pine_sapling" then
-			minetest.log("action", "A pine sapling grows into a tree at "..
-				minetest.pos_to_string(pos))
-			local snow = is_snow_nearby(pos)
-			if mapgen == "v6" then
-				default.grow_pine_tree(pos, snow)
-			elseif snow then
-				default.grow_new_snowy_pine_tree(pos)
-			else
-				default.grow_new_pine_tree(pos)
-			end
-		elseif node.name == "default:acacia_sapling" then
-			minetest.log("action", "An acacia sapling grows into a tree at "..
-				minetest.pos_to_string(pos))
-			default.grow_new_acacia_tree(pos)
-		elseif node.name == "default:aspen_sapling" then
-			minetest.log("action", "An aspen sapling grows into a tree at "..
-				minetest.pos_to_string(pos))
-			default.grow_new_aspen_tree(pos)
+	local mapgen = minetest.get_mapgen_params().mgname
+	local node = minetest.get_node(pos)
+	if node.name == "default:sapling" then
+		minetest.log("action", "A sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		if mapgen == "v6" then
+			default.grow_tree(pos, random(1, 4) == 1)
+		else
+			default.grow_new_apple_tree(pos)
 		end
+	elseif node.name == "default:junglesapling" then
+		minetest.log("action", "A jungle sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		if mapgen == "v6" then
+			default.grow_jungle_tree(pos)
+		else
+			default.grow_new_jungle_tree(pos)
+		end
+	elseif node.name == "default:pine_sapling" then
+		minetest.log("action", "A pine sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		local snow = is_snow_nearby(pos)
+		if mapgen == "v6" then
+			default.grow_pine_tree(pos, snow)
+		elseif snow then
+			default.grow_new_snowy_pine_tree(pos)
+		else
+			default.grow_new_pine_tree(pos)
+		end
+	elseif node.name == "default:acacia_sapling" then
+		minetest.log("action", "An acacia sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		default.grow_new_acacia_tree(pos)
+	elseif node.name == "default:aspen_sapling" then
+		minetest.log("action", "An aspen sapling grows into a tree at "..
+			minetest.pos_to_string(pos))
+		default.grow_new_aspen_tree(pos)
+	end
+end
+
+minetest.register_lbm({
+	name = "default:convert_saplings_to_node_timer",
+	nodenames = {"default:sapling", "default:junglesapling",
+			"default:pine_sapling", "default:acacia_sapling",
+			"default:aspen_sapling"},
+	action = function(pos)
+		minetest.get_node_timer(pos):start(math.random(1200, 2400))
 	end
 })
-
 
 --
 -- Tree generation


### PR DESCRIPTION
This PR requires @minetest/minetest#3677

Farming and plant growth has traditionally in minetest been
implemented using ABM's. These ABM's periodically tick and cause
plants to grow. The way these ABM's work has several side effects
that can be considered harmful.

Not to mention a comprehensive list of downsides here, but ABM's
are chance-dependent. That results in the chance that some nodes
potentially never get processed by the ABM action, and others get
processed always. One can easily find this effect by planting a large
field of crops, and seeing that some nodes are fully grown really
fast, and some just won't make it to fully grown status even after
hours or play time.

One could solve the problem by making the ABM's slower, and giving them
a 100% of action, but this would cause the entire field to grow a step
instantly at ABM intervals, and is both ugly, and a large number of
node updates that needs to be sent out to each client. Very un-ideal.

With NodeTimers though, each node will see a separate node timer event,
and they will likely not coalesce. This means that we can stop relying
on chance to distribute plant growth, and assign a single timer event
to grow the plant to the next phase.  Due to the timer implementation,
we won't ever miss a growth event, and we can re-scehdule them until
the plant has reached full size.

Previously, plants would attempt to grow every 9 seconds, with a
chance of 1/20. This means typically, a plant would need 9_20 seconds
to grow 1 phase, and since there are 8 steps, a typical plant growth
would require 9_20_8 ABM node events. (spread out over 9_8 ABM actual
underlying events per block, roughly).

because plants are likely not growing to full for a very long time
due to statistics working against it (5% of the crops take 20x longer
than the median to grow to full, we'd be seeing ABMs fire possibly
up to 9_20_8*20 with a 95% confidence interval (the actual math
is likely off, but the scale should be correct). That's incredibly
wasteful. We'd reach those conditions easily with 20 plant nodes.

Now, after we convert to NodeTimers, each plant node will see exactly
8 NodeTimer events, and no more. This scales lineairly per plant.

An additional problem in the farming mod was that the final fully-grown
plant was also included in the ABM, causing infinite more ABM's even
after the entire field had grown to completion.

Now, we're left with the problem that none of the pre-existing plants
have actual node timers started on them, and we do not want a new ABM
to fix this issue, since that would be wasteful.  Fortunately, there
is now an LBM concept, and we can use it to assure that NodeTimers
on crop nodes are properly started, and only have to do the actual
conversion once per block, ever.

We want to provide a fairly similar growth rate after this conversion
and as such I've resorted to modelling some statistical data. For this
I created a virtual 32x32 crop field with 9 steps (8 transitions)
as is the default wheat crop. We then apply a step where 1 in 20
plants in the field grows a step (randomly chosen) and count the
number of steps needed to get to 25%, 50, 75% and 95% grown.

The resulting data looks as follows:

25% - ~120 steps \* 9 sec / abm = 1080s
50% - ~152 steps               = 1368s
75% - ~194 steps               = 1746s
95% - ~255 steps               = 2295s

Next, we want to create a model where the chance that a crop grows
is 100% every node timer. Since there will only be 8 steps ever,
we want the slowest crops to grow in intervals of ~ 2300 / 8 seconds
and the fastest 1/4 of crops to grow 1080 / 8 seconds intervals.
We can roughly compare this to a normal distribution with a median
of 1400 with a stddev of ~350 (thick fingering this one here).

The rest is a bit of thick-fingering to get similar growth rates,
taking into account that ABM's fire regularly so if they're missed
it's fairly painless, but our timers are going to be 1-2 minutes
apart at minimum. I calculate the timer should be around 150s
median, and experimented with several jitter ranges.

Eventually I settled for now on [80,200] with a redo of [40,80],
meaning that each growth step at minimum takes (80 to 200) seconds,
and if a negative growth condition was found (darkness, soil not
wet, etc), then the growth step is retried every (40 to 80) seconds.

The end result is a growth period from seed to full in ~ 2.25
minetest days. This is a little bit shorter than the current
growth rate but the chances you'll miss timer ticks is a bit
larger, so in normal gameplay it should be fairly comparable.

A side effect is that fields grow to full yield fairly quickly
after crops make it to mature growth, and no crops are mature
a very long time before the majority grows to full. The spread
and view over a growing field is also fairly even, there's no
large updates with plenty of nodes. Just a node here or there
every second or so in large fields.

Ultimately, we get rid of ABM rollercoasters that cause tens of
node updates every 9 seconds. This will help multiplayer servers
likely a lot.

![](http://i.imgur.com/vdJHVcF.jpg)
