### PR TITLE
Fire: Allow placing only above flammable blocks

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -78,15 +78,19 @@ minetest.register_tool("fire:flint_and_steel", {
 		local pt = pointed_thing
 
 		if pt.type == "node" and minetest.get_node(pt.above).name == "air" then
-			if not minetest.is_protected(pt.above, player_name) then
-				minetest.set_node(pt.above, {name="fire:basic_flame"})
-			else
-				minetest.chat_send_player(player_name, "This area is protected")
+			itemstack:add_wear(1000)
+			local node_under = minetest.get_node(pt.under).name
+
+			if minetest.get_node_group(node_under, "flammable") >= 1 then
+				if not minetest.is_protected(pt.above, player_name) then
+					minetest.set_node(pt.above, {name = "fire:basic_flame"})
+				else
+					minetest.chat_send_player(player_name, "This area is protected")
+				end
 			end
 		end
-		
+
 		if not minetest.setting_getbool("creative_mode") then
-			itemstack:add_wear(1000)
 			return itemstack
 		end
 	end


### PR DESCRIPTION
Addresses https://github.com/minetest/minetest_game/issues/961 but needs feedbacks whether it should check neighbour flammable nodes in a radius or just the node below.

Cc: @paramat 
