### PR TITLE
Ability to Disable bones, drop items or keep inventory.

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -5,6 +5,12 @@
 # Whether creative mode (fast digging of all blocks, unlimited resources) should be enabled
 #creative_mode = false
 
+# Sets the behaviour of the inventory items when a player dies.
+#  "bones": Store all items inside a bone node but drop items if inside protected area
+#  "drop": Drop all items on the ground
+#  "keep": Player keeps all items
+#bones_mode = "bones"
+
 # The time in seconds after which the bones of a dead player can be looted by everyone
 # 0 to disable
 #share_bones_time = 1200

--- a/mods/bones/init.lua
+++ b/mods/bones/init.lua
@@ -1,7 +1,5 @@
 -- Minetest 0.4 mod: bones
--- See README.txt for licensing and other information. 
-
-bones = {}
+-- See README.txt for licensing and other information.
 
 local function is_owner(pos, name)
 	local owner = minetest.get_meta(pos):get_string("owner")
@@ -11,7 +9,7 @@ local function is_owner(pos, name)
 	return false
 end
 
-bones.bones_formspec =
+local bones_formspec =
 	"size[8,9]" ..
 	default.gui_bg ..
 	default.gui_bg_img ..
@@ -37,12 +35,12 @@ minetest.register_node("bones:bones", {
 		"bones_front.png"
 	},
 	paramtype2 = "facedir",
-	groups = {dig_immediate=2},
+	groups = {dig_immediate = 2},
 	sounds = default.node_sound_dirt_defaults({
-		footstep = {name="default_gravel_footstep", gain=0.5},
-		dug = {name="default_gravel_footstep", gain=1.0},
+		footstep = {name = "default_gravel_footstep", gain = 0.5},
+		dug = {name = "default_gravel_footstep", gain = 1.0},
 	}),
-	
+
 	can_dig = function(pos, player)
 		local inv = minetest.get_meta(pos):get_inventory()
 		local name = ""
@@ -51,46 +49,46 @@ minetest.register_node("bones:bones", {
 		end
 		return is_owner(pos, name) and inv:is_empty("main")
 	end,
-	
+
 	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
 		if is_owner(pos, player:get_player_name()) then
 			return count
 		end
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		return 0
 	end,
-	
+
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		if is_owner(pos, player:get_player_name()) then
 			return stack:get_count()
 		end
 		return 0
 	end,
-	
+
 	on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		local meta = minetest.get_meta(pos)
 		if meta:get_inventory():is_empty("main") then
 			minetest.remove_node(pos)
 		end
 	end,
-	
+
 	on_punch = function(pos, node, player)
-		if(not is_owner(pos, player:get_player_name())) then
+		if not is_owner(pos, player:get_player_name()) then
 			return
 		end
-		
-		if(minetest.get_meta(pos):get_string("infotext") == "") then
+
+		if minetest.get_meta(pos):get_string("infotext") == "" then
 			return
 		end
-		
+
 		local inv = minetest.get_meta(pos):get_inventory()
 		local player_inv = player:get_inventory()
 		local has_space = true
-		
-		for i=1,inv:get_size("main") do
+
+		for i = 1, inv:get_size("main") do
 			local stk = inv:get_stack("main", i)
 			if player_inv:room_for_item("main", stk) then
 				inv:set_stack("main", i, nil)
@@ -100,7 +98,7 @@ minetest.register_node("bones:bones", {
 				break
 			end
 		end
-		
+
 		-- remove bones if player emptied them
 		if has_space then
 			if player_inv:room_for_item("main", {name = "bones:bones"}) then
@@ -111,12 +109,12 @@ minetest.register_node("bones:bones", {
 			minetest.remove_node(pos)
 		end
 	end,
-	
+
 	on_timer = function(pos, elapsed)
 		local meta = minetest.get_meta(pos)
 		local time = meta:get_int("time") + elapsed
 		if time >= share_bones_time then
-			meta:set_string("infotext", meta:get_string("owner").."'s old bones")
+			meta:set_string("infotext", meta:get_string("owner") .. "'s old bones")
 			meta:set_string("owner", "")
 		else
 			meta:set_int("time", time)
@@ -131,13 +129,9 @@ local function may_replace(pos, player)
 	local node_name = minetest.get_node(pos).name
 	local node_definition = minetest.registered_nodes[node_name]
 
-	-- if the node is unknown, we let the protection mod decide
-	-- this is consistent with when a player could dig or not dig it
-	-- unknown decoration would often be removed
-	-- while unknown building materials in use would usually be left
+	-- if the node is unknown, we return false
 	if not node_definition then
-		-- only replace nodes that are not protected
-		return not minetest.is_protected(pos, player:get_player_name())
+		return false
 	end
 
 	-- allow replacing air and liquids
@@ -157,70 +151,92 @@ local function may_replace(pos, player)
 	return node_definition.buildable_to and not minetest.is_protected(pos, player:get_player_name())
 end
 
+local drop = function(pos, itemstack)
+	local obj = core.add_item(pos, itemstack:take_item(itemstack:get_count()))
+	if obj then
+		obj:setvelocity({
+			x = math.random(-10, 10) / 9,
+			y = 5,
+			z = math.random(-10, 10) / 9,
+		})
+	end
+end
+
 minetest.register_on_dieplayer(function(player)
-	if minetest.setting_getbool("creative_mode") then
+
+	local bones_mode = minetest.setting_get("bones_mode") or "bones"
+	if bones_mode ~= "bones" and bones_mode ~= "drop" and bones_mode ~= "keep" then
+		bones_mode = "bones"
+	end
+
+	-- return if keep inventory set or in creative mode
+	if bones_mode == "keep" or minetest.setting_getbool("creative_mode") then
 		return
 	end
-	
+
 	local player_inv = player:get_inventory()
 	if player_inv:is_empty("main") and
 		player_inv:is_empty("craft") then
 		return
 	end
 
-	local pos = player:getpos()
-	pos.x = math.floor(pos.x+0.5)
-	pos.y = math.floor(pos.y+0.5)
-	pos.z = math.floor(pos.z+0.5)
-	local param2 = minetest.dir_to_facedir(player:get_look_dir())
+	local pos = vector.round(player:getpos())
 	local player_name = player:get_player_name()
 
-	if (not may_replace(pos, player)) then
-		if (may_replace({x=pos.x, y=pos.y+1, z=pos.z}, player)) then
-			-- drop one node above if there's space
-			-- this should solve most cases of protection related deaths in which players dig straight down
-			-- yet keeps the bones reachable
-			pos.y = pos.y+1
-		else
-			-- drop items instead of delete
-			for i=1,player_inv:get_size("main") do
-				minetest.add_item(pos, player_inv:get_stack("main", i))
-			end
-			for i=1,player_inv:get_size("craft") do
-				minetest.add_item(pos, player_inv:get_stack("craft", i))
-			end
-			-- empty lists main and craft
-			player_inv:set_list("main", {})
-			player_inv:set_list("craft", {})
-			return
-		end
+	-- check if it's possible to place bones, if not go 1 higher
+	if bones_mode == "bones" and not may_replace(pos, player) then
+		pos.y = pos.y + 1
 	end
-	
-	minetest.set_node(pos, {name="bones:bones", param2=param2})
-	
+
+	-- still cannot place bones? change mode to 'drop'
+	if bones_mode == "bones" and not may_replace(pos, player) then
+		bones_mode = "drop"
+	end
+
+	if bones_mode == "drop" then
+
+		-- drop inventory items
+		for i = 1, player_inv:get_size("main") do
+			drop(pos, player_inv:get_stack("main", i))
+		end
+		player_inv:set_list("main", {})
+
+		-- drop crafting grid items
+		for i = 1, player_inv:get_size("craft") do
+			drop(pos, player_inv:get_stack("craft", i))
+		end
+		player_inv:set_list("craft", {})
+
+		drop(pos, ItemStack("bones:bones"))
+		return
+	end
+
+	local param2 = minetest.dir_to_facedir(player:get_look_dir())
+	minetest.set_node(pos, {name = "bones:bones", param2 = param2})
+
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
-	inv:set_size("main", 8*4)
+	inv:set_size("main", 8 * 4)
 	inv:set_list("main", player_inv:get_list("main"))
-	
-	for i=1,player_inv:get_size("craft") do
+
+	for i = 1, player_inv:get_size("craft") do
 		local stack = player_inv:get_stack("craft", i)
 		if inv:room_for_item("main", stack) then
 			inv:add_item("main", stack)
 		else
 			--drop if no space left
-			minetest.add_item(pos, stack)
+			drop(pos, stack)
 		end
 	end
-	
+
 	player_inv:set_list("main", {})
 	player_inv:set_list("craft", {})
-	
-	meta:set_string("formspec", bones.bones_formspec)
+
+	meta:set_string("formspec", bones_formspec)
 	meta:set_string("owner", player_name)
-	
+
 	if share_bones_time ~= 0 then
-		meta:set_string("infotext", player_name.."'s fresh bones")
+		meta:set_string("infotext", player_name .. "'s fresh bones")
 
 		if share_bones_time_early == 0 or not minetest.is_protected(pos, player_name) then
 			meta:set_int("time", 0)


### PR DESCRIPTION
I've added a setting to minetest.conf called `bones_mode` that allows the player or admin to enable, disable or drop items when you die.  Setting to `bones` will place bones or drop as items inside protected area, `drop` will drop all items and `keep` will leave your inventory alone.
