### PR TITLE
Add Crafting for Dirt with Grass

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -659,6 +659,21 @@ minetest.register_craft({
 	}
 })
 
+minetest.register_craft({
+	output = 'default:dirt_with_grass',
+	recipe = {
+		{'default:grass_1'},
+		{'default:dirt'},
+	}
+})
+
+minetest.register_craft({
+	output = 'default:dirt_with_dry_grass',
+	recipe = {
+		{'default:dry_grass_1'},
+		{'default:dirt'},
+	}
+})
 --
 -- Crafting (tool repair)
 --


### PR DESCRIPTION
This makes landscaping a bit easier.

You can combine one grass plant with one dirt to get grass.

**Note:** My git is quite primitive, and so I made this in the Github editor. If something is messed up, just tell me so I can shut this down and try to do it better.
