### PR TITLE
Make cacti hurt players.

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -891,6 +891,15 @@ minetest.register_node("default:cactus", {
 	groups = {snappy = 1, choppy = 3},
 	sounds = default.node_sound_wood_defaults(),
 	on_place = minetest.rotate_node,
+	damage_per_second = 1,
+	collision_box = {
+		type = "fixed",
+		-- Adjust collision box so it damages players that are too
+		-- close. We need to allow them to "enter" into the node a
+		-- little bit for this to actually happen. The top is low
+		-- enough that feet damage occurs if standing on it.
+		fixed = {-5/16,-1/2,-5/16,5/16,0.39,5/16},
+	},
 })
 
 minetest.register_node("default:papyrus", {


### PR DESCRIPTION
We can trivially make players get hurt if getting close to cacti,
by using the lava `damage_per_second` property. In order to
allow players to actually get hurt, they need to be "inside" the
node. We therefore modify the collision_box so that this is
possible to actually do. We make the box large enough to not
allow the player to go in between 2 adjacent cacti, and high enough
that it's almost as high as a normal block, but still hurting the
player's feet.

This doesn't work unless we also do a better job in the engine to
actually see if toes, shoulders and forehead are actually in the
cactus block, since the engine currently only checks for the
horizontal center of feet/body/head, and not the extremities. You
can, without penalty, put your player face into lava and not
get hurt. This is obviously wrong, and I'm submitting a separate
engine change for that.
