### PR TITLE
Doors: Use LBM instead of ABM to convert doors.

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -203,11 +203,10 @@ function doors.register(name, def)
 	end
 
 	-- replace old doors of this type automatically
-	minetest.register_abm({
+	minetest.register_lbm({
+		name = ":doors:replace_" .. name:gsub(":", "_"),
 		nodenames = {name.."_b_1", name.."_b_2"},
-		interval = 7.0,
-		chance = 1,
-		action = function(pos, node, active_object_count, active_object_count_wider)
+		action = function(pos, node)
 			local l = tonumber(node.name:sub(-1))
 			local meta = minetest.get_meta(pos)
 			local h = meta:get_int("right") + 1


### PR DESCRIPTION
This works much more efficiently to replace old style doors.

Suggest pulling this into 0.4.14. 

@kilbith I would appreciate a quick test with xdecor doors if you could, to confirm this works there as well.
