### PR TITLE
Fix '-' glitch and add creative.formspec_add

### DIFF
--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -98,6 +98,8 @@ local trash = minetest.create_detached_inventory("creative_trash", {
 })
 trash:set_size("main", 1)
 
+creative.additional_formspec = ""
+
 creative.set_creative_formspec = function(player, start_i)
 	local player_name = player:get_player_name()
 	local inv = player_inventory[player_name]
@@ -128,6 +130,7 @@ creative.set_creative_formspec = function(player, start_i)
 		"table[6.05,3.35;1.15,0.5;pagenum;#FFFF00," .. tostring(pagenum) .. ",#FFFFFF,/ " .. tostring(pagemax) .. "]" ..
 		default.get_hotbar_bg(0,4.7) ..
 		default.gui_bg .. default.gui_bg_img .. default.gui_slots
+		.. creative.additional_formspec
 	)
 end
 

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -98,7 +98,7 @@ local trash = minetest.create_detached_inventory("creative_trash", {
 })
 trash:set_size("main", 1)
 
-creative.additional_formspec = ""
+creative.formspec_add = ""
 
 creative.set_creative_formspec = function(player, start_i)
 	local player_name = player:get_player_name()
@@ -130,7 +130,7 @@ creative.set_creative_formspec = function(player, start_i)
 		"table[6.05,3.35;1.15,0.5;pagenum;#FFFF00," .. tostring(pagenum) .. ",#FFFFFF,/ " .. tostring(pagemax) .. "]" ..
 		default.get_hotbar_bg(0,4.7) ..
 		default.gui_bg .. default.gui_bg_img .. default.gui_slots
-		.. creative.additional_formspec
+		.. creative.formspec_add
 	)
 end
 

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -194,8 +194,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		creative.set_creative_formspec(player, 0)
 	else
 		local formspec = player:get_inventory_formspec()
-		local start_i = formspec:match("list%[.-" .. player_name .. ";.-;(%d+)%]")
-		start_i = tonumber(start_i) or 0
+		local start_i = player_inventory[player_name].start_i or 0
 
 		if fields.creative_prev then
 			start_i = start_i - 3*8
@@ -212,6 +211,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 		end
 
+		player_inventory[player_name].start_i = start_i
 		creative.set_creative_formspec(player, start_i)
 	end
 end)


### PR DESCRIPTION
This pull adds a new global variable called creative.additional_formspec that will allow mods to add to the creative inventory screen without the need to fork the mod altogether.  Simple solution that works already for inventory_plus' BACK button.

Also fixed the glitch [ #1072 ] when players use the '-' character in their username on server, creative inventory bugs out and wont go passed page 2.
