### PR TITLE
Remove eye offsetting hacks

### DIFF
--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -71,7 +71,6 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		end
 		player:set_pos(beds.pos[name])
 
-		-- physics, eye_offset, etc
 		local physics_override = beds.player[name].physics_override
 		beds.player[name] = nil
 		player:set_physics_override({
@@ -79,7 +78,6 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			jump = physics_override.jump,
 			gravity = physics_override.gravity
 		})
-		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
 		player:set_look_horizontal(math.random(1, 180) / 100)
 		player_api.player_attached[name] = false
 		hud_flags.wielditem = true

--- a/mods/carts/functions.lua
+++ b/mods/carts/functions.lua
@@ -19,14 +19,12 @@ function carts:manage_attachment(player, obj)
 
 	if status then
 		player:set_attach(obj, "", {x=0, y=-4.5, z=0}, {x=0, y=0, z=0})
-		player:set_eye_offset({x=0, y=-4, z=0},{x=0, y=-4, z=0})
 
 		-- player_api does not update the animation
 		-- when the player is attached, reset to default animation
 		player_api.set_animation(player, "stand")
 	else
 		player:set_detach()
-		player:set_eye_offset({x=0, y=0, z=0},{x=0, y=0, z=0})
 	end
 end
 


### PR DESCRIPTION
The eye height is now managed by player_api and automatically reduced when the sitting or laying animations are set. The resetting of eye height in beds was entirely unneeded and only had potential to break mods. For carts, this fixes the eye height being too low.