### PR TITLE
Workaround for sign regression with 5.12

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2605,7 +2605,7 @@ local function register_sign(material, desc, def)
 		end,
 		on_receive_fields = function(pos, formname, fields, sender)
 			if not fields.quit then
-				return
+				return -- workaround for https://github.com/luanti-org/luanti/issues/16187
 			end
 			local player_name = sender:get_player_name()
 			if minetest.is_protected(pos, player_name) then

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2604,12 +2604,14 @@ local function register_sign(material, desc, def)
 			meta:set_string("formspec", "field[text;;${text}]")
 		end,
 		on_receive_fields = function(pos, formname, fields, sender)
+			if not fields.quit then
+				return
+			end
 			local player_name = sender:get_player_name()
 			if minetest.is_protected(pos, player_name) then
 				minetest.record_protection_violation(pos, player_name)
 				return
 			end
-			if not fields.quit then return end
 			local text = fields.text
 			if not text then
 				return

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -2609,6 +2609,7 @@ local function register_sign(material, desc, def)
 				minetest.record_protection_violation(pos, player_name)
 				return
 			end
+			if not fields.quit then return end
 			local text = fields.text
 			if not text then
 				return


### PR DESCRIPTION
Issue is that when the build in "Proceed" button is pressed, on_receive_fields is called twice - once with a table of `{ quit = true, text = "user text" }` and then immediately after with a fields table of just `{text = "ExitButton"}`

Fix for https://github.com/luanti-org/luanti/issues/16187