### PR TITLE
Use new VoxelManip cleanup API

### DIFF
--- a/mods/carts/functions.lua
+++ b/mods/carts/functions.lua
@@ -41,15 +41,9 @@ end
 function carts:is_rail(pos, railtype)
 	local node = minetest.get_node(pos).name
 	if node == "ignore" then
-		local vm = minetest.get_voxel_manip()
-		local emin, emax = vm:read_from_map(pos, pos)
-		local area = VoxelArea:new{
-			MinEdge = emin,
-			MaxEdge = emax,
-		}
-		local data = vm:get_data()
-		local vi = area:indexp(pos)
-		node = minetest.get_name_from_content_id(data[vi])
+		-- we really need to know, so load it
+		minetest.load_area(pos)
+		node = minetest.get_node(pos).name
 	end
 	if minetest.get_item_group(node, "rail") == 0 then
 		return false

--- a/mods/default/trees.lua
+++ b/mods/default/trees.lua
@@ -132,7 +132,9 @@ function default.grow_tree(pos, is_apple_tree, bad)
 
 	vm:set_data(data)
 	vm:write_to_map()
-	vm:update_map()
+	if vm.close ~= nil then
+		vm:close()
+	end
 end
 
 -- Jungle tree
@@ -184,7 +186,9 @@ function default.grow_jungle_tree(pos, bad)
 
 	vm:set_data(data)
 	vm:write_to_map()
-	vm:update_map()
+	if vm.close ~= nil then
+		vm:close()
+	end
 end
 
 
@@ -310,7 +314,9 @@ function default.grow_pine_tree(pos, snow)
 
 	vm:set_data(data)
 	vm:write_to_map()
-	vm:update_map()
+	if vm.close ~= nil then
+		vm:close()
+	end
 end
 
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -332,6 +332,9 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owne
 
 	vm1:set_data(data)
 	vm1:write_to_map()
+	if vm1.close ~= nil then
+		vm1:close()
+	end
 
 	-- recalculate new radius
 	radius = math.floor(radius * math.pow(count, 1/3))
@@ -386,8 +389,10 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owne
 
 	vm:set_data(data)
 	vm:write_to_map()
-	vm:update_map()
 	vm:update_liquids()
+	if vm.close ~= nil then
+		vm:close()
+	end
 
 	-- call check_single_for_falling for everything within 1.5x blast radius
 	for y = -radius * 1.5, radius * 1.5 do


### PR DESCRIPTION
note:
* carts only used vmanips to load an area, this was replaced with `core.load_area`
* `vm:update_map()` is a no-op since at least 5.0.0, so was removed