### PR TITLE
Beds: Add support for pova and player_monoids

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,7 +19,10 @@ read_globals = {
 	-- Silence errors about custom table methods.
 	table = { fields = { "copy", "indexof" } },
 	-- Silence warnings about accessing undefined fields of global 'math'
-	math = { fields = { "sign" } }
+	math = { fields = { "sign" } },
+	-- Mod support
+	"player_monoids",
+	"pova",
 }
 
 -- Overwrites minetest.handle_node_drops

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -6,8 +6,8 @@ if enable_respawn == nil then
 end
 
 -- Physics override management mods (shadow the global variable)
-local player_monoids = core.get_modpath("player_monoids") and player_monoids
-local pova           = core.get_modpath("pova")           and pova
+local player_monoids = core.get_modpath("player_monoids") and _G["player_monoids"]
+local pova           = core.get_modpath("pova")           and _G["pova"]
 
 if player_monoids and not player_monoids.speed.checkout_branch then
 	-- This function exists since 2025-05-17

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -6,8 +6,8 @@ if enable_respawn == nil then
 end
 
 -- Physics override management mods (shadow the global variable)
-local player_monoids = core.get_modpath("player_monoids") and _G["player_monoids"]
-local pova           = core.get_modpath("pova")           and _G["pova"]
+local player_monoids = core.get_modpath("player_monoids") and player_monoids
+local pova           = core.get_modpath("pova")           and pova
 
 if player_monoids and not player_monoids.speed.checkout_branch then
 	-- This function exists since 2025-05-17
@@ -80,7 +80,7 @@ local function set_physics_override(player, put_to_bed)
 			pova.add_override(name, "force", OVERRIDES)
 			pova.do_override(player)
 		else
-			-- Fall back to default. May conflict with other mods.
+			-- Directly use engine API. May conflict with other mods.
 			pdata.physics_override = player:get_physics_override()
 			player:set_physics_override(OVERRIDES)
 		end

--- a/mods/beds/functions.lua
+++ b/mods/beds/functions.lua
@@ -5,6 +5,16 @@ if enable_respawn == nil then
 	enable_respawn = true
 end
 
+-- Physics override management mods (shadow the global variable)
+local player_monoids = core.get_modpath("player_monoids") and player_monoids
+local pova           = core.get_modpath("pova")           and pova
+
+if player_monoids and not player_monoids.speed.checkout_branch then
+	-- This function exists since 2025-05-17
+	core.log("warning", "[beds] player_monoids is too old, thus not supported.")
+	player_monoids = nil
+end
+
 -- support for MT game translation.
 local S = beds.get_translator
 
@@ -50,6 +60,51 @@ local function check_in_beds(players)
 	return #players > 0
 end
 
+local function set_physics_override(player, put_to_bed)
+	local IDENTIFIER = "beds:lie"
+	local OVERRIDES = {speed = 0, jump = 0, gravity = 0}
+
+	local name = player:get_player_name()
+	local pdata = beds.player[name]
+
+	if put_to_bed then -- Freeze player
+		if player_monoids then
+			for k, v in pairs(OVERRIDES) do
+				local monoid = player_monoids[k]
+				pdata["monoid_branch_" .. k] = monoid:get_active_branch(player)
+				-- Change the "context" of the physics overrides
+				local branch = monoid:checkout_branch(player, IDENTIFIER)
+				branch:add_change(player, v)
+			end
+		elseif pova then
+			pova.add_override(name, "force", OVERRIDES)
+			pova.do_override(player)
+		else
+			-- Fall back to default. May conflict with other mods.
+			pdata.physics_override = player:get_physics_override()
+			player:set_physics_override(OVERRIDES)
+		end
+	else -- Unfreeze player
+		if player_monoids then
+			for k, _ in pairs(OVERRIDES) do
+				local monoid = player_monoids[k]
+				monoid:checkout_branch(player, pdata["monoid_branch_" .. k])
+				monoid:get_branch(IDENTIFIER):delete(player)
+			end
+		elseif pova then
+			pova.del_override(name, "force")
+			pova.do_override(player)
+		else
+			-- Restore the changed fields
+			player:set_physics_override({
+				speed   = pdata.physics_override.speed,
+				jump    = pdata.physics_override.jump,
+				gravity = pdata.physics_override.gravity
+			})
+		end
+	end
+end
+
 local function lay_down(player, pos, bed_pos, state, skip)
 	local name = player:get_player_name()
 	local hud_flags = player:hud_get_flags()
@@ -72,13 +127,8 @@ local function lay_down(player, pos, bed_pos, state, skip)
 		player:set_pos(beds.pos[name])
 
 		-- physics, eye_offset, etc
-		local physics_override = beds.player[name].physics_override
+		set_physics_override(player, false)
 		beds.player[name] = nil
-		player:set_physics_override({
-			speed = physics_override.speed,
-			jump = physics_override.jump,
-			gravity = physics_override.gravity
-		})
 		player:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
 		player:set_look_horizontal(math.random(1, 180) / 100)
 		player_api.player_attached[name] = false
@@ -112,9 +162,9 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			return false
 		end
 
+		beds.player[name] = {}
 		beds.pos[name] = pos
 		beds.bed_position[name] = bed_pos
-		beds.player[name] = {physics_override = player:get_physics_override()}
 
 		local yaw, param2 = get_look_yaw(bed_pos)
 		player:set_look_horizontal(yaw)
@@ -126,7 +176,7 @@ local function lay_down(player, pos, bed_pos, state, skip)
 			y = bed_pos.y + 0.07,
 			z = bed_pos.z + dir.z / 2
 		}
-		player:set_physics_override({speed = 0, jump = 0, gravity = 0})
+		set_physics_override(player, true)
 		player:set_pos(p)
 		player_api.player_attached[name] = true
 		hud_flags.wielditem = false

--- a/mods/beds/mod.conf
+++ b/mods/beds/mod.conf
@@ -1,3 +1,4 @@
 name = beds
 description = Minetest Game mod: beds
 depends = default, wool, spawn
+optional_depends = player_monoids, pova


### PR DESCRIPTION
'ObjectRef:set_physics_override' is prone to cause conflicts between several mods if they override the same fields. This change implements support for 'pova' and recent versions of player_monoids for improved compatibility.

Fixes https://github.com/minetest-mods/stamina/issues/54 (likely among others).

**How to test**

1. Install [pova](https://codeberg.org/tenplus1/pova) and [player_monoids](https://github.com/minetest-mods/player_monoids/)
2. Enable exactly one (or none) of the two mods
3. Join the world
4. `/time 0`
5. Right-click on a bed. You must no longer be able to move
6. Wait for dawn
7. You must be able to move
8. Repeat with no mods enabled and the other supported mod.