### PR TITLE
Redo bucket foreign namespace registration fix

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -35,6 +35,7 @@ The bucket API allows registering new types of buckets for non-default liquids.
 
 The filled bucket item is returned to the player that uses an empty bucket pointing to the given liquid source.
 When punching with an empty bucket pointing to an entity or a non-liquid node, the on_punch of the entity or node will be triggered.
+The bucket API also allows registering buckets in other namespace using colon-prefixed itemname (i.e. ":cows:bucket_milk").
 
 
 Beds API

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -51,6 +51,8 @@ end
 -- This function can be called from any mod (that depends on bucket).
 function bucket.register_liquid(source, flowing, itemname, inventory_image, name,
 		groups, force_renew)
+	local itemname_raw = itemname
+	itemname = itemname and itemname:match(":(.+)") or itemname
 	bucket.liquids[source] = {
 		source = source,
 		flowing = flowing,
@@ -60,7 +62,7 @@ function bucket.register_liquid(source, flowing, itemname, inventory_image, name
 	bucket.liquids[flowing] = bucket.liquids[source]
 
 	if itemname ~= nil then
-		minetest.register_craftitem(itemname, {
+		minetest.register_craftitem(itemname_raw, {
 			description = name,
 			inventory_image = inventory_image,
 			stack_max = 1,

--- a/mods/bucket/init.lua
+++ b/mods/bucket/init.lua
@@ -52,7 +52,7 @@ end
 function bucket.register_liquid(source, flowing, itemname, inventory_image, name,
 		groups, force_renew)
 	local itemname_raw = itemname
-	itemname = itemname and itemname:match(":(.+)") or itemname
+	itemname = itemname and itemname:match("^:(.+)") or itemname
 	bucket.liquids[source] = {
 		source = source,
 		flowing = flowing,


### PR DESCRIPTION
Redo of #3199

My fault, I made a subtle mistake in the pattern I suggested, the explicit `:sub` solution would have worked.

Fix is https://github.com/luanti-org/minetest_game/commit/265fce3912ea27d9e697007f372f37061dbdbb15.