### PR TITLE
Improve flame sound logic

### DIFF
--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -194,34 +194,17 @@ if flame_sound then
 			core.sound_stop(handles[player_name])
 			handles[player_name] = nil
 		end
-		-- If flames
+		-- If flames present, find center of flame positions and play sound
 		if flames > 0 then
-			-- Find centre of flame positions
-			local fposmid = fpos[1]
-			-- If more than 1 flame
-			if #fpos > 1 then
-				local fposmin = areamax
-				local fposmax = areamin
+			local fposmid
+			if #fpos == 1 then
+				fposmid = fpos[1]
+			else
+				local fposmin = vector.copy(areamax)
+				local fposmax = vector.copy(areamin)
 				for i = 1, #fpos do
-					local fposi = fpos[i]
-					if fposi.x > fposmax.x then
-						fposmax.x = fposi.x
-					end
-					if fposi.y > fposmax.y then
-						fposmax.y = fposi.y
-					end
-					if fposi.z > fposmax.z then
-						fposmax.z = fposi.z
-					end
-					if fposi.x < fposmin.x then
-						fposmin.x = fposi.x
-					end
-					if fposi.y < fposmin.y then
-						fposmin.y = fposi.y
-					end
-					if fposi.z < fposmin.z then
-						fposmin.z = fposi.z
-					end
+					fposmin = vector.combine(fposmin, fpos[i], math.min)
+					fposmax = vector.combine(fposmax, fpos[i], math.max)
 				end
 				fposmid = vector.divide(vector.add(fposmin, fposmax), 2)
 			end
@@ -269,9 +252,6 @@ if flame_sound then
 	end)
 end
 
-
--- Deprecated function kept temporarily to avoid crashes if mod fire nodes call it
-function fire.update_sounds_around() end
 
 --
 -- ABMs

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -220,14 +220,19 @@ if flame_sound then
 				end
 				fposmid = vector.divide(vector.add(fposmin, fposmax), 2)
 			end
-			-- Play sound
-			local handle = core.sound_play("fire_fire", {
-				pos = fposmid,
-				to_player = player_name,
-				gain = math.min(0.06 * (1 + flames * 0.125), 0.18),
-				max_hear_distance = 32,
-				loop = true -- In case of lag
-			})
+			-- Play sound, fading in to avoid abrupt restarts on each cycle
+			local handle = core.sound_play(
+				{ name = "fire_fire", fade = 0.5 },
+				{
+					pos = fposmid,
+					to_player = player_name,
+					gain = math.min(0.06 * (1 + flames * 0.125), 0.18),
+					max_hear_distance = 32,
+					loop = true,
+					-- Start at a random offset so restarted sounds don't click
+					start_time = math.random() * cycle,
+				}
+			)
 			-- Store sound handle for this player
 			if handle then
 				handles[player_name] = handle

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -167,7 +167,7 @@ if flame_sound then
 
 	-- Parameters
 	local radius = 8 -- Flame node search radius around player
-	local cycle = 3 -- Cycle time for sound updates
+	local cycle = 1 -- Cycle time for sound updates
 
 	-- Update sound for player
 	function fire.update_player_sound(player)

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -177,7 +177,7 @@ if flame_sound then
 		local ppos = player:get_pos()
 		local areamin = vector.subtract(ppos, radius)
 		local areamax = vector.add(ppos, radius)
-		local fpos, num = core.find_nodes_in_area(
+		local fpos = core.find_nodes_in_area(
 			areamin,
 			areamax,
 			{ "fire:basic_flame", "fire:permanent_flame" }

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -9,7 +9,7 @@ local S = core.get_translator("fire")
 local fire_enabled = core.settings:get("enable_fire") or "auto"
 if fire_enabled == "auto" then
 	fire_enabled = core.is_singleplayer()
-	if core.settings:get_bool("disable_fire") then -- this is undocumented...?
+	if core.settings:get_bool("disable_fire") then -- This is undocumented...?
 		fire_enabled = false
 	end
 else
@@ -25,7 +25,7 @@ local function flood_flame(pos, _, newnode)
 	-- Play flame extinguish sound if liquid is not an 'igniter'
 	if core.get_item_group(newnode.name, "igniter") == 0 then
 		core.sound_play("fire_extinguish_flame",
-			{ pos = pos, max_hear_distance = 16, gain = 0.15 }, true)
+				{ pos = pos, max_hear_distance = 16, gain = 0.15 }, true)
 	end
 	-- Remove the flame
 	return false
@@ -89,7 +89,7 @@ core.register_tool("fire:flint_and_steel", {
 	on_use = function(itemstack, user, pointed_thing)
 		local sound_pos = pointed_thing.above or user:get_pos()
 		core.sound_play("fire_flint_and_steel",
-			{ pos = sound_pos, gain = 0.2, max_hear_distance = 8 }, true)
+				{ pos = sound_pos, gain = 0.2, max_hear_distance = 8 }, true)
 		local player_name = user:get_player_name()
 		if pointed_thing.type == "node" then
 			local node_under = core.get_node(pointed_thing.under).name
@@ -104,7 +104,7 @@ core.register_tool("fire:flint_and_steel", {
 			if nodedef.on_ignite then
 				nodedef.on_ignite(pointed_thing.under, user)
 			elseif core.get_item_group(node_under, "flammable") >= 1
-				and core.get_node(pointed_thing.above).name == "air" then
+					and core.get_node(pointed_thing.above).name == "air" then
 				if core.is_protected(pointed_thing.above, player_name) then
 					core.record_protection_violation(pointed_thing.above, player_name)
 					return
@@ -121,7 +121,7 @@ core.register_tool("fire:flint_and_steel", {
 			-- Tool break sound
 			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
 				core.sound_play(wdef.sound.breaks,
-					{ pos = sound_pos, gain = 0.5 }, true)
+						{ pos = sound_pos, gain = 0.5 }, true)
 			end
 			return itemstack
 		end
@@ -162,7 +162,7 @@ local flame_sound = core.settings:get_bool("flame_sound", true)
 
 if flame_sound then
 	local handles = {}
-	local fading_out = {} -- tracks handles that are fading out, pending cleanup
+	local fading_out = {} -- Tracks handles that are fading out, pending cleanup
 	local timer = 0
 
 	-- Parameters

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -181,9 +181,14 @@ if flame_sound then
 			areamax,
 			{ "fire:basic_flame", "fire:permanent_flame" }
 		)
+		-- Filter to a spherical radius (find_nodes_in_area returns an AABB)
+		for i = #fpos, 1, -1 do
+			if vector.distance(ppos, fpos[i]) > radius then
+				table.remove(fpos, i)
+			end
+		end
 		-- Total number of flames in radius
-		local flames = (num["fire:basic_flame"] or 0) +
-			(num["fire:permanent_flame"] or 0)
+		local flames = #fpos
 		-- Stop previous sound
 		if handles[player_name] then
 			core.sound_stop(handles[player_name])

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -34,7 +34,7 @@ end
 -- Flame nodes
 local fire_node = {
 	drawtype = "firelike",
-	tiles = { {
+	tiles = {{
 		name = "fire_basic_flame_animated.png",
 		animation = {
 			type = "vertical_frames",
@@ -42,8 +42,7 @@ local fire_node = {
 			aspect_h = 16,
 			length = 1
 		}
-	}
-	},
+	}},
 	inventory_image = "fire_basic_flame.png",
 	paramtype = "light",
 	light_source = 13,

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -25,7 +25,7 @@ local function flood_flame(pos, _, newnode)
 	-- Play flame extinguish sound if liquid is not an 'igniter'
 	if minetest.get_item_group(newnode.name, "igniter") == 0 then
 		minetest.sound_play("fire_extinguish_flame",
-			{pos = pos, max_hear_distance = 16, gain = 0.15}, true)
+			{ pos = pos, max_hear_distance = 16, gain = 0.15 }, true)
 	end
 	-- Remove the flame
 	return false
@@ -34,14 +34,15 @@ end
 -- Flame nodes
 local fire_node = {
 	drawtype = "firelike",
-	tiles = {{
+	tiles = { {
 		name = "fire_basic_flame_animated.png",
 		animation = {
 			type = "vertical_frames",
 			aspect_w = 16,
 			aspect_h = 16,
 			length = 1
-		}}
+		}
+	}
 	},
 	inventory_image = "fire_basic_flame.png",
 	paramtype = "light",
@@ -51,7 +52,7 @@ local fire_node = {
 	sunlight_propagates = true,
 	floodable = true,
 	damage_per_second = 4,
-	groups = {igniter = 2, dig_immediate = 3, fire = 1},
+	groups = { igniter = 2, dig_immediate = 3, fire = 1 },
 	drop = "",
 	on_flood = flood_flame
 }
@@ -61,7 +62,7 @@ local flame_fire_node = table.copy(fire_node)
 flame_fire_node.description = S("Fire")
 flame_fire_node.groups.not_in_creative_inventory = 1
 flame_fire_node.on_timer = function(pos)
-	if not minetest.find_node_near(pos, 1, {"group:flammable"}) then
+	if not minetest.find_node_near(pos, 1, { "group:flammable" }) then
 		minetest.remove_node(pos)
 		return
 	end
@@ -84,12 +85,12 @@ minetest.register_node("fire:permanent_flame", permanent_fire_node)
 minetest.register_tool("fire:flint_and_steel", {
 	description = S("Flint and Steel"),
 	inventory_image = "fire_flint_steel.png",
-	sound = {breaks = "default_tool_breaks"},
+	sound = { breaks = "default_tool_breaks" },
 
 	on_use = function(itemstack, user, pointed_thing)
 		local sound_pos = pointed_thing.above or user:get_pos()
 		minetest.sound_play("fire_flint_and_steel",
-			{pos = sound_pos, gain = 0.2, max_hear_distance = 8}, true)
+			{ pos = sound_pos, gain = 0.2, max_hear_distance = 8 }, true)
 		local player_name = user:get_player_name()
 		if pointed_thing.type == "node" then
 			local node_under = minetest.get_node(pointed_thing.under).name
@@ -104,13 +105,13 @@ minetest.register_tool("fire:flint_and_steel", {
 			if nodedef.on_ignite then
 				nodedef.on_ignite(pointed_thing.under, user)
 			elseif minetest.get_item_group(node_under, "flammable") >= 1
-					and minetest.get_node(pointed_thing.above).name == "air" then
+				and minetest.get_node(pointed_thing.above).name == "air" then
 				if minetest.is_protected(pointed_thing.above, player_name) then
 					minetest.record_protection_violation(pointed_thing.above, player_name)
 					return
 				end
 
-				minetest.set_node(pointed_thing.above, {name = "fire:basic_flame"})
+				minetest.set_node(pointed_thing.above, { name = "fire:basic_flame" })
 			end
 		end
 		if not minetest.is_creative_enabled(player_name) then
@@ -121,7 +122,7 @@ minetest.register_tool("fire:flint_and_steel", {
 			-- Tool break sound
 			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
 				minetest.sound_play(wdef.sound.breaks,
-					{pos = sound_pos, gain = 0.5}, true)
+					{ pos = sound_pos, gain = 0.5 }, true)
 			end
 			return itemstack
 		end
@@ -131,7 +132,7 @@ minetest.register_tool("fire:flint_and_steel", {
 minetest.register_craft({
 	output = "fire:flint_and_steel",
 	recipe = {
-		{"default:flint", "default:steel_ingot"}
+		{ "default:flint", "default:steel_ingot" }
 	}
 })
 
@@ -145,9 +146,9 @@ minetest.override_item("default:coalblock", {
 		end
 	end,
 	on_ignite = function(pos)
-		local flame_pos = {x = pos.x, y = pos.y + 1, z = pos.z}
+		local flame_pos = { x = pos.x, y = pos.y + 1, z = pos.z }
 		if minetest.get_node(flame_pos).name == "air" then
-			minetest.set_node(flame_pos, {name = "fire:permanent_flame"})
+			minetest.set_node(flame_pos, { name = "fire:permanent_flame" })
 		end
 	end
 })
@@ -178,7 +179,7 @@ if flame_sound then
 		local fpos, num = minetest.find_nodes_in_area(
 			areamin,
 			areamax,
-			{"fire:basic_flame", "fire:permanent_flame"}
+			{ "fire:basic_flame", "fire:permanent_flame" }
 		)
 		-- Total number of flames in radius
 		local flames = (num["fire:basic_flame"] or 0) +
@@ -234,7 +235,7 @@ if flame_sound then
 		end
 	end
 
-	-- Cycle for updating players sounds
+	-- Cycle for updating player sounds
 	minetest.register_globalstep(function(dtime)
 		timer = timer + dtime
 		if timer < cycle then
@@ -270,15 +271,15 @@ if fire_enabled then
 	-- Ignite neighboring nodes, add basic flames
 	minetest.register_abm({
 		label = "Ignite flame",
-		nodenames = {"group:flammable"},
-		neighbors = {"group:igniter"},
+		nodenames = { "group:flammable" },
+		neighbors = { "group:igniter" },
 		interval = 7,
 		chance = 12,
 		catch_up = false,
 		action = function(pos)
-			local p = minetest.find_node_near(pos, 1, {"air"})
+			local p = minetest.find_node_near(pos, 1, { "air" })
 			if p then
-				minetest.set_node(p, {name = "fire:basic_flame"})
+				minetest.set_node(p, { name = "fire:basic_flame" })
 			end
 		end
 	})
@@ -286,13 +287,13 @@ if fire_enabled then
 	-- Remove flammable nodes around basic flame
 	minetest.register_abm({
 		label = "Remove flammable nodes",
-		nodenames = {"fire:basic_flame"},
+		nodenames = { "fire:basic_flame" },
 		neighbors = "group:flammable",
 		interval = 5,
 		chance = 18,
 		catch_up = false,
 		action = function(pos)
-			local p = minetest.find_node_near(pos, 1, {"group:flammable"})
+			local p = minetest.find_node_near(pos, 1, { "group:flammable" })
 			if not p then
 				return
 			end

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -3,17 +3,17 @@
 -- Global namespace for functions
 fire = {}
 
-local S = minetest.get_translator("fire")
+local S = core.get_translator("fire")
 
 -- Default to enabled in singleplayer
-local fire_enabled = minetest.settings:get("enable_fire") or "auto"
+local fire_enabled = core.settings:get("enable_fire") or "auto"
 if fire_enabled == "auto" then
-	fire_enabled = minetest.is_singleplayer()
-	if minetest.settings:get_bool("disable_fire") then -- this is undocumented...?
+	fire_enabled = core.is_singleplayer()
+	if core.settings:get_bool("disable_fire") then -- this is undocumented...?
 		fire_enabled = false
 	end
 else
-	fire_enabled = minetest.is_yes(fire_enabled)
+	fire_enabled = core.is_yes(fire_enabled)
 end
 
 --
@@ -23,8 +23,8 @@ end
 -- Flood flame function
 local function flood_flame(pos, _, newnode)
 	-- Play flame extinguish sound if liquid is not an 'igniter'
-	if minetest.get_item_group(newnode.name, "igniter") == 0 then
-		minetest.sound_play("fire_extinguish_flame",
+	if core.get_item_group(newnode.name, "igniter") == 0 then
+		core.sound_play("fire_extinguish_flame",
 			{ pos = pos, max_hear_distance = 16, gain = 0.15 }, true)
 	end
 	-- Remove the flame
@@ -62,66 +62,66 @@ local flame_fire_node = table.copy(fire_node)
 flame_fire_node.description = S("Fire")
 flame_fire_node.groups.not_in_creative_inventory = 1
 flame_fire_node.on_timer = function(pos)
-	if not minetest.find_node_near(pos, 1, { "group:flammable" }) then
-		minetest.remove_node(pos)
+	if not core.find_node_near(pos, 1, { "group:flammable" }) then
+		core.remove_node(pos)
 		return
 	end
 	-- Restart timer
 	return true
 end
 flame_fire_node.on_construct = function(pos)
-	minetest.get_node_timer(pos):start(math.random(30, 60))
+	core.get_node_timer(pos):start(math.random(30, 60))
 end
 
-minetest.register_node("fire:basic_flame", flame_fire_node)
+core.register_node("fire:basic_flame", flame_fire_node)
 
 -- Permanent flame node
 local permanent_fire_node = table.copy(fire_node)
 permanent_fire_node.description = S("Permanent Fire")
 
-minetest.register_node("fire:permanent_flame", permanent_fire_node)
+core.register_node("fire:permanent_flame", permanent_fire_node)
 
 -- Flint and Steel
-minetest.register_tool("fire:flint_and_steel", {
+core.register_tool("fire:flint_and_steel", {
 	description = S("Flint and Steel"),
 	inventory_image = "fire_flint_steel.png",
 	sound = { breaks = "default_tool_breaks" },
 
 	on_use = function(itemstack, user, pointed_thing)
 		local sound_pos = pointed_thing.above or user:get_pos()
-		minetest.sound_play("fire_flint_and_steel",
+		core.sound_play("fire_flint_and_steel",
 			{ pos = sound_pos, gain = 0.2, max_hear_distance = 8 }, true)
 		local player_name = user:get_player_name()
 		if pointed_thing.type == "node" then
-			local node_under = minetest.get_node(pointed_thing.under).name
-			local nodedef = minetest.registered_nodes[node_under]
+			local node_under = core.get_node(pointed_thing.under).name
+			local nodedef = core.registered_nodes[node_under]
 			if not nodedef then
 				return
 			end
-			if minetest.is_protected(pointed_thing.under, player_name) then
-				minetest.record_protection_violation(pointed_thing.under, player_name)
+			if core.is_protected(pointed_thing.under, player_name) then
+				core.record_protection_violation(pointed_thing.under, player_name)
 				return
 			end
 			if nodedef.on_ignite then
 				nodedef.on_ignite(pointed_thing.under, user)
-			elseif minetest.get_item_group(node_under, "flammable") >= 1
-				and minetest.get_node(pointed_thing.above).name == "air" then
-				if minetest.is_protected(pointed_thing.above, player_name) then
-					minetest.record_protection_violation(pointed_thing.above, player_name)
+			elseif core.get_item_group(node_under, "flammable") >= 1
+				and core.get_node(pointed_thing.above).name == "air" then
+				if core.is_protected(pointed_thing.above, player_name) then
+					core.record_protection_violation(pointed_thing.above, player_name)
 					return
 				end
 
-				minetest.set_node(pointed_thing.above, { name = "fire:basic_flame" })
+				core.set_node(pointed_thing.above, { name = "fire:basic_flame" })
 			end
 		end
-		if not minetest.is_creative_enabled(player_name) then
+		if not core.is_creative_enabled(player_name) then
 			-- Wear tool
 			local wdef = itemstack:get_definition()
 			itemstack:add_wear_by_uses(66)
 
 			-- Tool break sound
 			if itemstack:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-				minetest.sound_play(wdef.sound.breaks,
+				core.sound_play(wdef.sound.breaks,
 					{ pos = sound_pos, gain = 0.5 }, true)
 			end
 			return itemstack
@@ -129,7 +129,7 @@ minetest.register_tool("fire:flint_and_steel", {
 	end
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "fire:flint_and_steel",
 	recipe = {
 		{ "default:flint", "default:steel_ingot" }
@@ -138,17 +138,17 @@ minetest.register_craft({
 
 -- Override coalblock to enable permanent flame above
 -- Coalblock is non-flammable to avoid unwanted basic_flame nodes
-minetest.override_item("default:coalblock", {
+core.override_item("default:coalblock", {
 	after_destruct = function(pos)
 		pos.y = pos.y + 1
-		if minetest.get_node(pos).name == "fire:permanent_flame" then
-			minetest.remove_node(pos)
+		if core.get_node(pos).name == "fire:permanent_flame" then
+			core.remove_node(pos)
 		end
 	end,
 	on_ignite = function(pos)
 		local flame_pos = { x = pos.x, y = pos.y + 1, z = pos.z }
-		if minetest.get_node(flame_pos).name == "air" then
-			minetest.set_node(flame_pos, { name = "fire:permanent_flame" })
+		if core.get_node(flame_pos).name == "air" then
+			core.set_node(flame_pos, { name = "fire:permanent_flame" })
 		end
 	end
 })
@@ -159,7 +159,7 @@ minetest.override_item("default:coalblock", {
 --
 
 -- Enable if no setting present
-local flame_sound = minetest.settings:get_bool("flame_sound", true)
+local flame_sound = core.settings:get_bool("flame_sound", true)
 
 if flame_sound then
 	local handles = {}
@@ -176,7 +176,7 @@ if flame_sound then
 		local ppos = player:get_pos()
 		local areamin = vector.subtract(ppos, radius)
 		local areamax = vector.add(ppos, radius)
-		local fpos, num = minetest.find_nodes_in_area(
+		local fpos, num = core.find_nodes_in_area(
 			areamin,
 			areamax,
 			{ "fire:basic_flame", "fire:permanent_flame" }
@@ -186,7 +186,7 @@ if flame_sound then
 			(num["fire:permanent_flame"] or 0)
 		-- Stop previous sound
 		if handles[player_name] then
-			minetest.sound_stop(handles[player_name])
+			core.sound_stop(handles[player_name])
 			handles[player_name] = nil
 		end
 		-- If flames
@@ -221,7 +221,7 @@ if flame_sound then
 				fposmid = vector.divide(vector.add(fposmin, fposmax), 2)
 			end
 			-- Play sound
-			local handle = minetest.sound_play("fire_fire", {
+			local handle = core.sound_play("fire_fire", {
 				pos = fposmid,
 				to_player = player_name,
 				gain = math.min(0.06 * (1 + flames * 0.125), 0.18),
@@ -236,24 +236,24 @@ if flame_sound then
 	end
 
 	-- Cycle for updating player sounds
-	minetest.register_globalstep(function(dtime)
+	core.register_globalstep(function(dtime)
 		timer = timer + dtime
 		if timer < cycle then
 			return
 		end
 
 		timer = 0
-		local players = minetest.get_connected_players()
+		local players = core.get_connected_players()
 		for n = 1, #players do
 			fire.update_player_sound(players[n])
 		end
 	end)
 
 	-- Stop sound and clear handle on player leave
-	minetest.register_on_leaveplayer(function(player)
+	core.register_on_leaveplayer(function(player)
 		local player_name = player:get_player_name()
 		if handles[player_name] then
-			minetest.sound_stop(handles[player_name])
+			core.sound_stop(handles[player_name])
 			handles[player_name] = nil
 		end
 	end)
@@ -269,7 +269,7 @@ function fire.update_sounds_around() end
 
 if fire_enabled then
 	-- Ignite neighboring nodes, add basic flames
-	minetest.register_abm({
+	core.register_abm({
 		label = "Ignite flame",
 		nodenames = { "group:flammable" },
 		neighbors = { "group:igniter" },
@@ -277,15 +277,15 @@ if fire_enabled then
 		chance = 12,
 		catch_up = false,
 		action = function(pos)
-			local p = minetest.find_node_near(pos, 1, { "air" })
+			local p = core.find_node_near(pos, 1, { "air" })
 			if p then
-				minetest.set_node(p, { name = "fire:basic_flame" })
+				core.set_node(p, { name = "fire:basic_flame" })
 			end
 		end
 	})
 
 	-- Remove flammable nodes around basic flame
-	minetest.register_abm({
+	core.register_abm({
 		label = "Remove flammable nodes",
 		nodenames = { "fire:basic_flame" },
 		neighbors = "group:flammable",
@@ -293,17 +293,17 @@ if fire_enabled then
 		chance = 18,
 		catch_up = false,
 		action = function(pos)
-			local p = minetest.find_node_near(pos, 1, { "group:flammable" })
+			local p = core.find_node_near(pos, 1, { "group:flammable" })
 			if not p then
 				return
 			end
-			local flammable_node = minetest.get_node(p)
-			local def = minetest.registered_nodes[flammable_node.name]
+			local flammable_node = core.get_node(p)
+			local def = core.registered_nodes[flammable_node.name]
 			if def.on_burn then
 				def.on_burn(p)
 			else
-				minetest.remove_node(p)
-				minetest.check_for_falling(p)
+				core.remove_node(p)
+				core.check_for_falling(p)
 			end
 		end
 	})

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -163,6 +163,7 @@ local flame_sound = core.settings:get_bool("flame_sound", true)
 
 if flame_sound then
 	local handles = {}
+	local fading_out = {} -- tracks handles that are fading out, pending cleanup
 	local timer = 0
 
 	-- Parameters
@@ -189,13 +190,22 @@ if flame_sound then
 		end
 		-- Total number of flames in radius
 		local flames = #fpos
-		-- Stop previous sound
-		if handles[player_name] then
-			core.sound_stop(handles[player_name])
-			handles[player_name] = nil
+
+		-- Clean up any completed fade-outs from the previous cycle
+		if fading_out[player_name] then
+			core.sound_stop(fading_out[player_name])
+			fading_out[player_name] = nil
 		end
-		-- If flames present, find center of flame positions and play sound
-		if flames > 0 then
+
+		if handles[player_name] then
+			-- Sound already playing: fade out if player has left range
+			if flames == 0 then
+				core.sound_fade(handles[player_name], -0.5, 0.0)
+				fading_out[player_name] = handles[player_name]
+				handles[player_name] = nil
+			end
+		elseif flames > 0 then
+			-- Player has entered range: find center of flames and start sound
 			local fposmid
 			if #fpos == 1 then
 				fposmid = fpos[1]
@@ -208,7 +218,7 @@ if flame_sound then
 				end
 				fposmid = vector.divide(vector.add(fposmin, fposmax), 2)
 			end
-			-- Play sound, fading in to avoid abrupt restarts on each cycle
+			-- Fade in so the sound enters smoothly
 			local handle = core.sound_play(
 				{ name = "fire_fire", fade = 0.5 },
 				{
@@ -217,11 +227,8 @@ if flame_sound then
 					gain = math.min(0.06 * (1 + flames * 0.125), 0.18),
 					max_hear_distance = 32,
 					loop = true,
-					-- Start at a random offset so restarted sounds don't click
-					start_time = math.random() * cycle,
 				}
 			)
-			-- Store sound handle for this player
 			if handle then
 				handles[player_name] = handle
 			end
@@ -242,12 +249,16 @@ if flame_sound then
 		end
 	end)
 
-	-- Stop sound and clear handle on player leave
+	-- Stop sound and clear handles on player leave
 	core.register_on_leaveplayer(function(player)
 		local player_name = player:get_player_name()
 		if handles[player_name] then
 			core.sound_stop(handles[player_name])
 			handles[player_name] = nil
+		end
+		if fading_out[player_name] then
+			core.sound_stop(fading_out[player_name])
+			fading_out[player_name] = nil
 		end
 	end)
 end


### PR DESCRIPTION
I was looking at the code for mtg's fire, having been recommended to it when trying to figure out how to do looping sounds emitted from nodes.  I ended up finding ways to improve the current implementation.

This PR improves:
- namespace use (minetest to core)
- fpos logic to use vectors
- nearby fire node detection to filter to actual distance (spherical radius instead of a bounding box)
- sound update responsiveness
- adds playback fade in/out