### PR TITLE
Update GitHub Actions pipeline

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -5,8 +5,8 @@ jobs:
   luacheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+
       - name: Luacheck
         uses: lunarmodules/luacheck@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,15 @@ jobs:
         cfg:
           - { image: 'ghcr.io/minetest/minetest:5.9.0' }
           - { image: 'ghcr.io/minetest/minetest:5.10.0' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.11.0' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.12.0' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.13.0' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.14.0' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.15.2' }
+          - { image: 'ghcr.io/luanti-org/luanti:5.16.1' }
           - { image: 'ghcr.io/luanti-org/luanti:master' } # latest git
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - run: ./utils/test/run.sh
       env:


### PR DESCRIPTION
- Bump `actions/checkout` to v7 (resolve CI Node 20 warning)
- Add other Luanti versions in the testing pipeline