### PR TITLE
Fix TNT API

### DIFF
--- a/game_api.txt
+++ b/game_api.txt
@@ -553,15 +553,17 @@ TNT API
   * `side`  Side tiles. By default the name of the tnt with a suffix of `_side.png`.
   * `top`  Top tile. By default the name of the tnt with a suffix of `_top.png`.
   * `bottom` Bottom tile. By default the name of the tnt with a suffix of `_bottom.png`.
-  * `burning` Top tile when lit. By default the name of the tnt with a suffix of `_top_burning_animated.png".
+  * `burning` Top tile when lit. By default the name of the tnt with a suffix of `_top_burning_animated.png`.
 
-`tnt.boom(position[, definition])`
+`tnt.boom(position[, definition, igniter])`
 
 ^ Create an explosion.
 
 * `position` The center of explosion.
 * `definition` The TNT definion as passed to `tnt.register` with the following addition:
  * `explode_center` false by default which removes TNT node on blast, when true will explode center node.
+   Effect only applies if `ignore_on_blast` is set to false.
+* `igniter` Name of player causing explosion (optional, used for protection checks).
 
 `tnt.burn(position, [nodename])`
 

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -686,7 +686,7 @@ function tnt.register_tnt(def)
 			on_ignite = function(pos, igniter)
                 if not minetest.is_protected(pos, igniter:get_player_name()) then
                     minetest.swap_node(pos, {name = name .. "_burning"})
-                   	minetest.registered_nodes[name .. "_burning"].on_construct(pos)
+                    minetest.registered_nodes[name .. "_burning"].on_construct(pos)
                 end
 			end,
 		})

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -424,19 +424,19 @@ local function tnt_explode(pos, radius, ignore_protection, ignore_on_blast, owne
 		queued_data.fn(queued_data.pos)
 	end
 
-	minetest.log("action", "TNT owned by " .. owner .. " detonated at " ..
+	minetest.log("action", "TNT/Explosion owned/caused by " .. owner .. " detonated at " ..
 		minetest.pos_to_string(pos) .. " with radius " .. radius)
 
 	return drops, radius
 end
 
-function tnt.boom(pos, def)
+function tnt.boom(pos, def, igniter)
 	def = def or {}
 	def.radius = def.radius or 1
 	def.damage_radius = def.damage_radius or def.radius * 2
 	local meta = minetest.get_meta(pos)
-	local owner = meta:get_string("owner")
-	if not def.explode_center and def.ignore_protection ~= true then
+	local owner = igniter or meta:get_string("owner")
+	if not def.explode_center and (def.ignore_protection or not minetest.is_protected(pos, owner)) then
 		minetest.set_node(pos, {name = "tnt:boom"})
 	end
 	local sound = def.sound or "tnt_explode"
@@ -658,6 +658,9 @@ function tnt.register_tnt(def)
 				end
 			end,
 			on_punch = function(pos, node, puncher)
+                if minetest.is_protected(pos, puncher:get_player_name()) then
+                    return
+                end
 				if puncher:get_wielded_item():get_name() == "default:torch" then
 					minetest.swap_node(pos, {name = name .. "_burning"})
 					minetest.registered_nodes[name .. "_burning"].on_construct(pos)
@@ -681,8 +684,10 @@ function tnt.register_tnt(def)
 				minetest.registered_nodes[name .. "_burning"].on_construct(pos)
 			end,
 			on_ignite = function(pos, igniter)
-				minetest.swap_node(pos, {name = name .. "_burning"})
-				minetest.registered_nodes[name .. "_burning"].on_construct(pos)
+                if not minetest.is_protected(pos, igniter:get_player_name()) then
+                    minetest.swap_node(pos, {name = name .. "_burning"})
+                   	minetest.registered_nodes[name .. "_burning"].on_construct(pos)
+                end
 			end,
 		})
 	end


### PR DESCRIPTION
This fixes unexpected behavior of the TNT API without changing existing functionality.


#### Fixed unexpected behavior:
- Right now, registering a tnt node via this API with `ignore_protection = true` results in a TNT causing no explosion at all. This seems to be a consequence of a careless implementation of the `explode_center` option.
- Secondly, when calling the tnt.boom() function, it is possible to define the explosion just like a tnt definition with `ignore_protection = false`. However as of now there is no possibility to specify a player responsible for the explosion.
- In Addition to that it's currently possible for anyone to ignite a TNT placed by the owner in protected areas, causing a destructive explosion.

#### What's changed:
- Fixed conflict between `ignore_protection` and `explode_center`.
- Added optional `igniter` parameter to tnt.boom(); if not set, behaves as usual.
- Added protection checks upon ignition.
----

This has been partially addressed in already existing PRs. While the tnt mod in general could use a revamp imo, this PR only aims to fix obvious bugs/inconsistencies, given that mtg currently is only in maintenance mode.