### PR TITLE
Add craftguide pause on load

### DIFF
--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -145,7 +145,7 @@ local function cache_usages(recipe)
 	end
 end
 
-minetest.register_on_mods_loaded(function()
+minetest.after(1, function()
 	for name, def in pairs(minetest.registered_items) do
 		if show_item(def) then
 			local recipes = get_craftable_recipes(name)

--- a/mods/mtg_craftguide/init.lua
+++ b/mods/mtg_craftguide/init.lua
@@ -145,7 +145,7 @@ local function cache_usages(recipe)
 	end
 end
 
-minetest.after(1, function()
+minetest.after(0.01, function()
 	for name, def in pairs(minetest.registered_items) do
 		if show_item(def) then
 			local recipes = get_craftable_recipes(name)


### PR DESCRIPTION
This adds a 0.1 second pause before building the crafting guide, as some mods wait until others have loaded before doing additional registrations.  This simple delay fixes the missing craft recipes in certain mods.